### PR TITLE
Add histogram statistics overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Methane
+
+This repository contains analysis utilities for methane concentration datasets.
+
+The histogram analysis now annotates the mean, median and standard deviation
+on the generated plot.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 This repository contains analysis utilities for methane concentration datasets.
 
-The histogram analysis now annotates the mean, median and standard deviation
-on the generated plot.
+The histogram analysis now annotates basic statistics (mean, median, standard
+deviation, minimum and maximum) on the generated plot.

--- a/analysis/histogram.py
+++ b/analysis/histogram.py
@@ -11,11 +11,29 @@ class HistogramAnalysis:
 
     @staticmethod
     def graficar_histograma_global(df, archivo='methane3_histogram.png'):
+        """Create a histogram and overlay basic statistics."""
         plt.figure(figsize=(10, 5))
         plt.hist(df['methane3'], bins=50, color='skyblue', edgecolor='black')
+
+        mean_val = df['methane3'].mean()
+        median_val = df['methane3'].median()
+        std_val = df['methane3'].std()
+
+        plt.axvline(mean_val, color='red', linestyle='--', label=f"Media: {mean_val:.2f}")
+        plt.axvline(median_val, color='green', linestyle='--', label=f"Mediana: {median_val:.2f}")
+
+        stats_text = f"Media: {mean_val:.2f}\nMediana: {median_val:.2f}\nDesv. estándar: {std_val:.2f}"
+        plt.gca().text(0.95, 0.95, stats_text,
+                       transform=plt.gca().transAxes,
+                       fontsize=9,
+                       verticalalignment='top',
+                       horizontalalignment='right',
+                       bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.8))
+
         plt.title("Histograma global de concentración de metano (methane3)")
         plt.xlabel("Concentración de metano (ppb)")
         plt.ylabel("Frecuencia")
+        plt.legend()
         plt.tight_layout()
         plt.savefig(archivo, dpi=300)
         plt.close()

--- a/analysis/histogram.py
+++ b/analysis/histogram.py
@@ -18,11 +18,21 @@ class HistogramAnalysis:
         mean_val = df['methane3'].mean()
         median_val = df['methane3'].median()
         std_val = df['methane3'].std()
+        min_val = df['methane3'].min()
+        max_val = df['methane3'].max()
 
         plt.axvline(mean_val, color='red', linestyle='--', label=f"Media: {mean_val:.2f}")
         plt.axvline(median_val, color='green', linestyle='--', label=f"Mediana: {median_val:.2f}")
+        plt.axvline(min_val, color='purple', linestyle=':', label=f"Mínimo: {min_val:.2f}")
+        plt.axvline(max_val, color='orange', linestyle=':', label=f"Máximo: {max_val:.2f}")
 
-        stats_text = f"Media: {mean_val:.2f}\nMediana: {median_val:.2f}\nDesv. estándar: {std_val:.2f}"
+        stats_text = (
+            f"Media: {mean_val:.2f}\n"
+            f"Mediana: {median_val:.2f}\n"
+            f"Desv. estándar: {std_val:.2f}\n"
+            f"Mínimo: {min_val:.2f}\n"
+            f"Máximo: {max_val:.2f}"
+        )
         plt.gca().text(0.95, 0.95, stats_text,
                        transform=plt.gca().transAxes,
                        fontsize=9,


### PR DESCRIPTION
## Summary
- compute mean, median and standard deviation for methane concentrations
- annotate the statistics on the histogram plot
- refresh README

## Testing
- `python -m py_compile analysis/histogram.py`
- `python - <<'PY'
from analysis.histogram import HistogramAnalysis
files, err = HistogramAnalysis.run_histogram_analysis('tula_original.csv')
print('files:', files)
print('err:', err)
PY`

------
https://chatgpt.com/codex/tasks/task_e_685c15955e6c8322a3bf5b79f60d9c90