### PR TITLE
Add kmeans latlon counts in plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Methane
+
+This repository contains analysis utilities for methane concentration datasets.
+
+The histogram analysis now annotates basic statistics (mean, median, standard
+deviation, minimum and maximum) on the generated plot.
+
+For K-means clustering in `lat_lon` mode, the analysis no longer outputs the
+`tula_kmeans_lat_lon_clusters.csv` or `tula_kmeans_lat_lon_conteos.txt` files.
+Instead, cluster counts appear in the title of the spatial scatter plot.

--- a/analysis/histogram.py
+++ b/analysis/histogram.py
@@ -11,11 +11,39 @@ class HistogramAnalysis:
 
     @staticmethod
     def graficar_histograma_global(df, archivo='methane3_histogram.png'):
+        """Create a histogram and overlay basic statistics."""
         plt.figure(figsize=(10, 5))
         plt.hist(df['methane3'], bins=50, color='skyblue', edgecolor='black')
+
+        mean_val = df['methane3'].mean()
+        median_val = df['methane3'].median()
+        std_val = df['methane3'].std()
+        min_val = df['methane3'].min()
+        max_val = df['methane3'].max()
+
+        plt.axvline(mean_val, color='red', linestyle='--', label=f"Media: {mean_val:.2f}")
+        plt.axvline(median_val, color='green', linestyle='--', label=f"Mediana: {median_val:.2f}")
+        plt.axvline(min_val, color='purple', linestyle=':', label=f"Mínimo: {min_val:.2f}")
+        plt.axvline(max_val, color='orange', linestyle=':', label=f"Máximo: {max_val:.2f}")
+
+        stats_text = (
+            f"Media: {mean_val:.2f}\n"
+            f"Mediana: {median_val:.2f}\n"
+            f"Desv. estándar: {std_val:.2f}\n"
+            f"Mínimo: {min_val:.2f}\n"
+            f"Máximo: {max_val:.2f}"
+        )
+        plt.gca().text(0.95, 0.95, stats_text,
+                       transform=plt.gca().transAxes,
+                       fontsize=9,
+                       verticalalignment='top',
+                       horizontalalignment='right',
+                       bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.8))
+
         plt.title("Histograma global de concentración de metano (methane3)")
         plt.xlabel("Concentración de metano (ppb)")
         plt.ylabel("Frecuencia")
+        plt.legend()
         plt.tight_layout()
         plt.savefig(archivo, dpi=300)
         plt.close()

--- a/analysis/kmeans_analysis.py
+++ b/analysis/kmeans_analysis.py
@@ -75,17 +75,25 @@ class KMeansAnalysis:
             df[cluster_column] = kmeans.fit_predict(features_scaled)
             
             generated_files = []
-            
-            output_csv = f'tula_kmeans_{mode}_clusters.csv'
-            df.to_csv(output_csv, index=False)
-            generated_files.append(output_csv)
-            
+
+            if mode != 'lat_lon':
+                output_csv = f'tula_kmeans_{mode}_clusters.csv'
+                df.to_csv(output_csv, index=False)
+                generated_files.append(output_csv)
+
             conteos = df[cluster_column].value_counts().sort_index()
-            conteo_file = f'tula_kmeans_{mode}_conteos.txt'
-            with open(conteo_file, 'w') as f:
-                f.write(f"Cantidad de puntos por cluster (K-Means {mode}):\n")
-                f.write(str(conteos))
-            generated_files.append(conteo_file)
+            conteo_str = ", ".join(
+                f"{cl}: {cnt}" for cl, cnt in conteos.items()
+            )
+
+            if mode != 'lat_lon':
+                conteo_file = f'tula_kmeans_{mode}_conteos.txt'
+                with open(conteo_file, 'w') as f:
+                    f.write(
+                        f"Cantidad de puntos por cluster (K-Means {mode}):\n"
+                    )
+                    f.write(str(conteos))
+                generated_files.append(conteo_file)
             
             plt.figure(figsize=(12, 4))
             plt.subplot(1, 3, 1)
@@ -131,7 +139,10 @@ class KMeansAnalysis:
                 legend=True
             )
             ctx.add_basemap(ax, source=ctx.providers.CartoDB.Positron)
-            ax.set_title(f'Distribución espacial por cluster (K-Means, K={best_k}) - {mode}')
+            title = f'Distribución espacial por cluster (K-Means, K={best_k}) - {mode}'
+            if conteo_str:
+                title += f"\nConteos: {conteo_str}"
+            ax.set_title(title)
             ax.set_axis_off()
             plt.tight_layout()
             map_file = f'tula_kmeans_{mode}_space_scatter_basemap.png'


### PR DESCRIPTION
## Summary
- show K-means cluster counts in the spatial scatter plot title
- skip the counts file for `lat_lon` mode
- refresh README accordingly

## Testing
- `python -m py_compile analysis/histogram.py analysis/kmeans_analysis.py app.py`
- `pip install pandas matplotlib numpy pillow seaborn geopandas contextily scikit-learn`
- `python -m py_compile analysis/histogram.py analysis/kmeans_analysis.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c15955e6c8322a3bf5b79f60d9c90