### PR TITLE
Add stacked methane histograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,35 @@ deviation, minimum and maximum) on the generated plot.
 
 For K-means clustering in `lat_lon` mode, the analysis no longer outputs the
 `tula_kmeans_lat_lon_clusters.csv` or `tula_kmeans_lat_lon_conteos.txt` files.
-Instead, cluster counts appear in the title of the spatial scatter plot.
+Cluster counts are shown in the title of the spatial scatter plot.
+
+Similarly, for the `time_lat_lon` mode the analysis does not generate
+`tula_kmeans_time_lat_lon_clusters.csv` or
+`tula_kmeans_time_lat_lon_conteos.txt`. The cluster count statistics that would
+normally be stored in the text file are displayed directly in the title of the
+`tula_kmeans_time_lat_lon_space_scatter_basemap.png` plot.
+
+The WCSS, Silhouette Score and Davies-Bouldin Index plots for all K-means modes
+highlight the chosen cluster count using a dashed vertical line and a purple
+scatter marker. Each plot now labels the marker with text like ``K = 3`` placed
+to the right of the point, making the optimal cluster number easy to identify.
+
+Each analysis also saves a final histogram. When methane data is present the
+histogram displays the stacked distribution of ``methane3`` values for each
+cluster, so the methane concentration ranges can be compared directly.
+Otherwise a simple bar chart of cluster counts is produced.
+
+For the ``lat_lon_methane`` mode four plots are produced:
+``tula_kmeans_lat_lon_methane_metricas_vs_K.png``,
+``tula_kmeans_lat_lon_methane_space_scatter_basemap.png``,
+``tula_methane3_box_swarmplot_lat_lon_methane_cluster.png`` and
+``tula_kmeans_lat_lon_methane_cluster_histogram.png``. No CSV or text files are
+saved and intermediate methane histogram or boxplot images are not generated.
+
+In ``time_lat_lon_methane`` mode five plots are produced:
+``tula_kmeans_time_lat_lon_methane_metricas_vs_K.png``,
+``tula_kmeans_time_lat_lon_methane_space_scatter_basemap.png``,
+``tula_kmeans_time_lat_lon_methane_time_scatter.png``,
+``tula_methane3_box_swarmplot_time_lat_lon_methane_cluster.png`` and
+``tula_kmeans_time_lat_lon_methane_cluster_histogram.png``. Other plots as well
+as CSV or text files are omitted.

--- a/analysis/kmeans_analysis.py
+++ b/analysis/kmeans_analysis.py
@@ -76,7 +76,7 @@ class KMeansAnalysis:
             
             generated_files = []
 
-            if mode != 'lat_lon':
+            if mode not in ['lat_lon', 'time_lat_lon', 'lat_lon_methane', 'time_lat_lon_methane']:
                 output_csv = f'tula_kmeans_{mode}_clusters.csv'
                 df.to_csv(output_csv, index=False)
                 generated_files.append(output_csv)
@@ -86,7 +86,7 @@ class KMeansAnalysis:
                 f"{cl}: {cnt}" for cl, cnt in conteos.items()
             )
 
-            if mode != 'lat_lon':
+            if mode not in ['lat_lon', 'time_lat_lon', 'lat_lon_methane', 'time_lat_lon_methane']:
                 conteo_file = f'tula_kmeans_{mode}_conteos.txt'
                 with open(conteo_file, 'w') as f:
                     f.write(
@@ -95,29 +95,62 @@ class KMeansAnalysis:
                     f.write(str(conteos))
                 generated_files.append(conteo_file)
             
-            plt.figure(figsize=(12, 4))
-            plt.subplot(1, 3, 1)
-            plt.plot(K_range, wcss_list, marker='o')
-            plt.title('WCSS vs K')
-            plt.xlabel('Número de clusters (K)')
-            plt.ylabel('WCSS')
-            plt.grid(True, linestyle='--', alpha=0.3)
-            
-            plt.subplot(1, 3, 2)
-            plt.plot(K_range, silhouette_list, marker='o', color='green')
-            plt.title('Silhouette Score vs K')
-            plt.xlabel('Número de clusters (K)')
-            plt.ylabel('Silhouette Score')
-            plt.grid(True, linestyle='--', alpha=0.3)
-            
-            plt.subplot(1, 3, 3)
-            plt.plot(K_range, db_index_list, marker='o', color='red')
-            plt.title('Davies-Bouldin Index vs K')
-            plt.xlabel('Número de clusters (K)')
-            plt.ylabel('DB Index')
-            plt.grid(True, linestyle='--', alpha=0.3)
-            
-            plt.tight_layout()
+            fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+
+            best_idx = best_k - K_range.start
+
+            axes[0].plot(K_range, wcss_list, marker='o')
+            axes[0].axvline(best_k, color='purple', linestyle='--')
+            axes[0].scatter(best_k, wcss_list[best_idx], color='purple', zorder=5)
+            axes[0].annotate(
+                f"K = {best_k}",
+                xy=(best_k, wcss_list[best_idx]),
+                xytext=(8, 0),
+                textcoords='offset points',
+                ha='left',
+                va='center',
+                color='purple'
+            )
+            axes[0].set_title('WCSS vs K')
+            axes[0].set_xlabel('Número de clusters (K)')
+            axes[0].set_ylabel('WCSS')
+            axes[0].grid(True, linestyle='--', alpha=0.3)
+
+            axes[1].plot(K_range, silhouette_list, marker='o', color='green')
+            axes[1].axvline(best_k, color='purple', linestyle='--')
+            axes[1].scatter(best_k, silhouette_list[best_idx], color='purple', zorder=5)
+            axes[1].annotate(
+                f"K = {best_k}",
+                xy=(best_k, silhouette_list[best_idx]),
+                xytext=(8, 0),
+                textcoords='offset points',
+                ha='left',
+                va='center',
+                color='purple'
+            )
+            axes[1].set_title('Silhouette Score vs K')
+            axes[1].set_xlabel('Número de clusters (K)')
+            axes[1].set_ylabel('Silhouette Score')
+            axes[1].grid(True, linestyle='--', alpha=0.3)
+
+            axes[2].plot(K_range, db_index_list, marker='o', color='red')
+            axes[2].axvline(best_k, color='purple', linestyle='--')
+            axes[2].scatter(best_k, db_index_list[best_idx], color='purple', zorder=5)
+            axes[2].annotate(
+                f"K = {best_k}",
+                xy=(best_k, db_index_list[best_idx]),
+                xytext=(8, 0),
+                textcoords='offset points',
+                ha='left',
+                va='center',
+                color='purple'
+            )
+            axes[2].set_title('Davies-Bouldin Index vs K')
+            axes[2].set_xlabel('Número de clusters (K)')
+            axes[2].set_ylabel('DB Index')
+            axes[2].grid(True, linestyle='--', alpha=0.3)
+
+            fig.tight_layout()
             metrics_file = f'tula_kmeans_{mode}_metricas_vs_K.png'
             plt.savefig(metrics_file, dpi=300)
             plt.close()
@@ -176,74 +209,153 @@ class KMeansAnalysis:
                 generated_files.append(time_scatter_file)
             
             if include_methane:
+                if mode in ['lat_lon_methane', 'time_lat_lon_methane']:
+                    plt.figure(figsize=(10, 6))
+                    sns.boxplot(
+                        data=df,
+                        x=cluster_column,
+                        y='methane3',
+                        palette='tab10'
+                    )
+                    sns.swarmplot(
+                        data=df,
+                        x=cluster_column,
+                        y='methane3',
+                        color='black',
+                        alpha=0.5,
+                        size=2
+                    )
+                    plt.title(
+                        f'Distribución combinada de methane3 por cluster (K={best_k}) - {mode}'
+                    )
+                    plt.xlabel('Cluster')
+                    plt.ylabel('methane3 (ppb)')
+                    plt.grid(axis='y', linestyle='--', alpha=0.3)
+                    plt.tight_layout()
+                    swarm_file = f'tula_methane3_box_swarmplot_{mode}_cluster.png'
+                    plt.savefig(swarm_file, dpi=300)
+                    plt.close()
+                    generated_files.append(swarm_file)
+                else:
+                    clusters = sorted(df[cluster_column].unique())
+                    for cl in clusters:
+                        subset = df[df[cluster_column] == cl]['methane3']
+                        if not subset.empty:
+                            plt.figure(figsize=(6, 4))
+                            plt.hist(
+                                subset,
+                                bins=30,
+                                edgecolor='black'
+                            )
+                            plt.title(
+                                f'Distribución de methane3 en el cluster {cl} - {mode}'
+                            )
+                            plt.xlabel('methane3 (ppb)')
+                            plt.ylabel('Cantidad de puntos')
+                            plt.grid(axis='y', linestyle='--', alpha=0.3)
+                            plt.tight_layout()
+                            hist_file = (
+                                f'tula_methane3_hist_{mode}_cluster_{cl}.png'
+                            )
+                            plt.savefig(hist_file, dpi=300)
+                            plt.close()
+                            generated_files.append(hist_file)
+
+                    plt.figure(figsize=(10, 6))
+                    sns.boxplot(
+                        data=df,
+                        x=cluster_column,
+                        y='methane3',
+                        palette='tab10'
+                    )
+                    plt.title(
+                        f'Distribución de methane3 por cluster (K={best_k}) - {mode}'
+                    )
+                    plt.xlabel('Cluster')
+                    plt.ylabel('methane3 (ppb)')
+                    plt.grid(axis='y', linestyle='--', alpha=0.3)
+                    plt.tight_layout()
+                    box_file = f'tula_methane3_boxplot_{mode}_cluster.png'
+                    plt.savefig(box_file, dpi=300)
+                    plt.close()
+                    generated_files.append(box_file)
+
+                    plt.figure(figsize=(10, 6))
+                    sns.boxplot(
+                        data=df,
+                        x=cluster_column,
+                        y='methane3',
+                        palette='tab10'
+                    )
+                    sns.swarmplot(
+                        data=df,
+                        x=cluster_column,
+                        y='methane3',
+                        color='black',
+                        alpha=0.5,
+                        size=2
+                    )
+                    plt.title(
+                        f'Distribución combinada de methane3 por cluster (K={best_k}) - {mode}'
+                    )
+                    plt.xlabel('Cluster')
+                    plt.ylabel('methane3 (ppb)')
+                    plt.grid(axis='y', linestyle='--', alpha=0.3)
+                    plt.tight_layout()
+                    swarm_file = f'tula_methane3_box_swarmplot_{mode}_cluster.png'
+                    plt.savefig(swarm_file, dpi=300)
+                    plt.close()
+                    generated_files.append(swarm_file)
+
+                    resumen = (
+                        df.groupby(cluster_column)['methane3'].describe().round(2)
+                    )
+                    resumen.reset_index(inplace=True)
+                    resumen.columns.name = None
+                    resumen.to_csv(
+                        f'tula_methane3_resumen_por_cluster_{mode}.csv', index=False
+                    )
+                    generated_files.append(
+                        f'tula_methane3_resumen_por_cluster_{mode}.csv'
+                    )
+
+            hist_clusters_file = f'tula_kmeans_{mode}_cluster_histogram.png'
+            if include_methane:
                 clusters = sorted(df[cluster_column].unique())
-                for cl in clusters:
-                    subset = df[df[cluster_column] == cl]['methane3']
-                    if not subset.empty:
-                        plt.figure(figsize=(6, 4))
-                        plt.hist(
-                            subset,
-                            bins=30,
-                            edgecolor='black'
-                        )
-                        plt.title(f'Distribución de methane3 en el cluster {cl} - {mode}')
-                        plt.xlabel('methane3 (ppb)')
-                        plt.ylabel('Cantidad de puntos')
-                        plt.grid(axis='y', linestyle='--', alpha=0.3)
-                        plt.tight_layout()
-                        hist_file = f'tula_methane3_hist_{mode}_cluster_{cl}.png'
-                        plt.savefig(hist_file, dpi=300)
-                        plt.close()
-                        generated_files.append(hist_file)
-                
+                data = [df[df[cluster_column] == cl]['methane3'] for cl in clusters]
                 plt.figure(figsize=(10, 6))
-                sns.boxplot(
-                    data=df,
-                    x=cluster_column,
-                    y='methane3',
-                    palette='tab10'
+                bins = np.histogram_bin_edges(df['methane3'], bins=30)
+                plt.hist(
+                    data,
+                    bins=bins,
+                    stacked=True,
+                    label=[f'Cluster {cl}' for cl in clusters],
                 )
-                plt.title(f'Distribución de methane3 por cluster (K={best_k}) - {mode}')
-                plt.xlabel('Cluster')
-                plt.ylabel('methane3 (ppb)')
+                plt.title(
+                    f'Distribuci\u00f3n apilada de methane3 por cluster (K={best_k}) - {mode}'
+                )
+                plt.xlabel('methane3 (ppb)')
+                plt.ylabel('Cantidad de puntos')
+                plt.legend(title='Cluster')
                 plt.grid(axis='y', linestyle='--', alpha=0.3)
                 plt.tight_layout()
-                box_file = f'tula_methane3_boxplot_{mode}_cluster.png'
-                plt.savefig(box_file, dpi=300)
+                plt.savefig(hist_clusters_file, dpi=300)
                 plt.close()
-                generated_files.append(box_file)
-                
-                plt.figure(figsize=(10, 6))
-                sns.boxplot(
-                    data=df,
-                    x=cluster_column,
-                    y='methane3',
-                    palette='tab10'
+                generated_files.append(hist_clusters_file)
+            else:
+                plt.figure(figsize=(8, 5))
+                plt.bar(conteos.index.astype(str), conteos.values, color='tab:blue')
+                plt.title(
+                    f'Conteo de puntos por cluster (K={best_k}) - {mode}'
                 )
-                sns.swarmplot(
-                    data=df,
-                    x=cluster_column,
-                    y='methane3',
-                    color='black',
-                    alpha=0.5,
-                    size=2
-                )
-                plt.title(f'Distribución combinada de methane3 por cluster (K={best_k}) - {mode}')
                 plt.xlabel('Cluster')
-                plt.ylabel('methane3 (ppb)')
+                plt.ylabel('Cantidad de puntos')
                 plt.grid(axis='y', linestyle='--', alpha=0.3)
                 plt.tight_layout()
-                swarm_file = f'tula_methane3_box_swarmplot_{mode}_cluster.png'
-                plt.savefig(swarm_file, dpi=300)
+                plt.savefig(hist_clusters_file, dpi=300)
                 plt.close()
-                generated_files.append(swarm_file)
-                
-                resumen = df.groupby(cluster_column)['methane3'].describe().round(2)
-                resumen.reset_index(inplace=True)
-                resumen.columns.name = None
-                resumen.to_csv(f'tula_methane3_resumen_por_cluster_{mode}.csv', index=False)
-                generated_files.append(f'tula_methane3_resumen_por_cluster_{mode}.csv')
-            
+                generated_files.append(hist_clusters_file)
+
             return generated_files, None
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- plot stacked histograms of methane values by cluster when methane data is present
- document the new stacked-histogram output, clarifying methane concentration ranges

## Testing
- `python -m py_compile analysis/*.py app.py`
- `flake8` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3364a86c83228ea4457cc4ece30b