### PR TITLE
Add Hurst exponent note to DFA plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ In ``time_lat_lon_methane`` mode five plots are produced:
 ``tula_methane3_box_swarmplot_time_lat_lon_methane_cluster.png`` and
 ``tula_methane3_stacked_hist_time_lat_lon_methane_cluster.png``. Other plots
 as well as CSV or text files are omitted.
+
+The DFA (Detrended Fluctuation Analysis) plot labels the y-axis as "Función de
+fluctuación F(n)" and includes a short note summarizing common interpretations of
+the Hurst exponent values.

--- a/analysis/dfa.py
+++ b/analysis/dfa.py
@@ -34,7 +34,24 @@ class DFAAnalysis:
             ax.loglog(scales, F, 'o', label='Datos')
             ax.loglog(scales, np.exp(intercept)*scales**H, label=f'Ajuste H={H:.3f}')
             ax.set_xlabel('Escala n')
-            ax.set_ylabel('F(n)')
+            ax.set_ylabel('Función de fluctuación F(n)')
+            note = (
+                'H=0.5: uncorrelated (white noise)\n'
+                'H <0.5: anti-correlated\n'
+                '0.5<H <1: long-range correlations (persistent)\n'
+                'H=1: 1/f noise (pink noise)\n'
+                'H>1: non-stationary behavior (random walk, Brownian motion)'
+            )
+            ax.text(
+                0.95,
+                0.05,
+                note,
+                transform=ax.transAxes,
+                fontsize=8,
+                verticalalignment='bottom',
+                horizontalalignment='right',
+                bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.8)
+            )
             ax.legend()
             fig.tight_layout()
             fig.savefig("DFA.png", dpi=300, bbox_inches='tight')


### PR DESCRIPTION
## Summary
- show full name for the fluctuation function in DFA
- annotate DFA plot with a guide to Hurst exponent values
- document DFA plot improvements

## Testing
- `python -m py_compile analysis/dfa.py`

------
https://chatgpt.com/codex/tasks/task_e_68629d993780832284bd51a86a37ea8f