### PR TITLE
Add Hurst exponent note to DFA plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ In ``time_lat_lon_methane`` mode five plots are produced:
 ``tula_methane3_box_swarmplot_time_lat_lon_methane_cluster.png`` and
 ``tula_methane3_stacked_hist_time_lat_lon_methane_cluster.png``. Other plots
 as well as CSV or text files are omitted.
+
+The DFA (Detrended Fluctuation Analysis) plot labels the y-axis as
+``Función de fluctuación F(n)`` and includes a short note summarizing common
+interpretations of the Hurst exponent values.
+
+The PSA (Power Spectral Analysis) now generates only
+``loglog_psd_with_beta.png``. This plot contains a brief guide to common values
+of the spectral exponent:
+``β=0: white noise``, ``β=1: pink noise (1/f)``, ``β=2: Brownian noise``.

--- a/analysis/dfa.py
+++ b/analysis/dfa.py
@@ -34,7 +34,24 @@ class DFAAnalysis:
             ax.loglog(scales, F, 'o', label='Datos')
             ax.loglog(scales, np.exp(intercept)*scales**H, label=f'Ajuste H={H:.3f}')
             ax.set_xlabel('Escala n')
-            ax.set_ylabel('F(n)')
+            ax.set_ylabel('Función de fluctuación F(n)')
+            note = (
+                'H=0.5: uncorrelated (white noise)\n'
+                'H <0.5: anti-correlated\n'
+                '0.5<H <1: long-range correlations (persistent)\n'
+                'H=1: 1/f noise (pink noise)\n'
+                'H>1: non-stationary behavior (random walk, Brownian motion)'
+            )
+            ax.text(
+                0.95,
+                0.05,
+                note,
+                transform=ax.transAxes,
+                fontsize=8,
+                verticalalignment='bottom',
+                horizontalalignment='right',
+                bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.8)
+            )
             ax.legend()
             fig.tight_layout()
             fig.savefig("DFA.png", dpi=300, bbox_inches='tight')

--- a/analysis/psa.py
+++ b/analysis/psa.py
@@ -9,7 +9,6 @@ class PSAAnalysis:
             import matplotlib.pyplot as plt
             from scipy.fft import fft, fftfreq
             from scipy.stats import linregress
-            from statsmodels.tsa.stattools import acf, kpss
 
             df = pd.read_csv(data_file, parse_dates=['measurement_time'])
             df.sort_values('measurement_time', inplace=True)
@@ -18,33 +17,6 @@ class PSAAnalysis:
             slope, intercept, *_ = linregress(df['time_numeric'], df['methane3'])
             df['methane3_detrended'] = df['methane3'] - (slope * df['time_numeric'] + intercept)
 
-            plt.figure(figsize=(12, 4))
-            plt.plot(df['measurement_time'], df['methane3'], label='Original', alpha=0.6)
-            plt.plot(df['measurement_time'], df['methane3_detrended'], label='Detrended')
-            plt.title('Methane Concentration: Original vs Detrended')
-            plt.xlabel('Time')
-            plt.ylabel('Methane3')
-            plt.legend()
-            plt.tight_layout()
-            plt.savefig('methane_original_vs_detrended.png', dpi=300)
-            plt.close()
-
-            acf_values = acf(df['methane3_detrended'], nlags=100)
-            plt.figure(figsize=(10, 4))
-            plt.stem(range(len(acf_values)), acf_values)
-            plt.title('Autocorrelation of Detrended Methane3')
-            plt.xlabel('Lag')
-            plt.ylabel('ACF')
-            plt.tight_layout()
-            plt.savefig('autocorrelation_detrended_methane3.png', dpi=300)
-            plt.close()
-
-            stat, p_value, _, crit_vals = kpss(df['methane3_detrended'], regression='c')
-            with open('kpss_results.txt', 'w') as f:
-                f.write(f'KPSS Test Statistic: {stat:.4f}\n')
-                f.write(f'p-value: {p_value:.4f}\n')
-                for k, v in crit_vals.items():
-                    f.write(f'Critical Value {k}: {v:.4f}\n')
 
             signal = df['methane3_detrended'].to_numpy()
             n = len(signal)
@@ -66,6 +38,21 @@ class PSAAnalysis:
             plt.ylabel('log10(Power)')
             plt.legend()
             plt.grid(True)
+            note = (
+                'β=0: white noise\n'
+                'β=1: pink noise (1/f)\n'
+                'β=2: Brownian noise'
+            )
+            plt.gca().text(
+                0.95,
+                0.95,
+                note,
+                transform=plt.gca().transAxes,
+                fontsize=8,
+                verticalalignment='top',
+                horizontalalignment='right',
+                bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.8)
+            )
             plt.tight_layout()
             plt.savefig('loglog_psd_with_beta.png', dpi=300)
             plt.close()
@@ -81,22 +68,7 @@ class PSAAnalysis:
                 else:
                     f.write("Strong low-frequency dominance or nonstationary trend\n")
 
-            plt.figure(figsize=(10, 4))
-            plt.plot(xf, 2.0/n * np.abs(yf[0:n//2]))
-            plt.title('Power Spectral Density of Detrended Methane3')
-            plt.xlabel('Frequency [Hz]')
-            plt.ylabel('Amplitude')
-            plt.grid(True)
-            plt.tight_layout()
-            plt.savefig('power_spectral_density_methane3.png', dpi=300)
-            plt.close()
-
-            return [
-                'methane_original_vs_detrended.png',
-                'autocorrelation_detrended_methane3.png',
-                'loglog_psd_with_beta.png',
-                'power_spectral_density_methane3.png'
-            ], None
+            return ['loglog_psd_with_beta.png'], None
 
         except Exception as e:
             return [], str(e)


### PR DESCRIPTION
## Summary
- show full name for the fluctuation function in DFA
- annotate DFA plot with a guide to Hurst exponent values
- simplify PSA to only output the log-log PSD plot with a beta note
- document PSA and DFA plot improvements

## Testing
- `python -m py_compile analysis/psa.py`
- `python -m py_compile analysis/dfa.py`


------
https://chatgpt.com/codex/tasks/task_e_68629d993780832284bd51a86a37ea8f