### PR TITLE
Add application highlight to LSTM plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,20 @@ In ``time_lat_lon_methane`` mode five plots are produced:
 ``tula_methane3_box_swarmplot_time_lat_lon_methane_cluster.png`` and
 ``tula_methane3_stacked_hist_time_lat_lon_methane_cluster.png``. Other plots
 as well as CSV or text files are omitted.
+
+The DFA (Detrended Fluctuation Analysis) plot labels the y-axis as
+``Función de fluctuación F(n)`` and includes a short note summarizing common
+interpretations of the Hurst exponent values.
+
+The PSA (Power Spectral Analysis) now generates only
+``loglog_psd_with_beta.png``. This plot contains a brief guide to common values
+of the spectral exponent:
+``β=0: white noise``, ``β=1: pink noise (1/f)``, ``β=2: Brownian noise``. The
+plot also includes the calculated β value with a short explanation such as
+``Pink noise-like process`` or ``Brownian or red noise`` depending on the
+result.
+
+The LSTM analysis returns a single figure ``LSTM.png`` that overlays the
+training and testing predictions with the historical data and appends the
+future forecast for six months. The forecasted period (application stage) is
+highlighted in the plot for clarity.

--- a/analysis/dfa.py
+++ b/analysis/dfa.py
@@ -34,7 +34,24 @@ class DFAAnalysis:
             ax.loglog(scales, F, 'o', label='Datos')
             ax.loglog(scales, np.exp(intercept)*scales**H, label=f'Ajuste H={H:.3f}')
             ax.set_xlabel('Escala n')
-            ax.set_ylabel('F(n)')
+            ax.set_ylabel('Función de fluctuación F(n)')
+            note = (
+                'H=0.5: uncorrelated (white noise)\n'
+                'H <0.5: anti-correlated\n'
+                '0.5<H <1: long-range correlations (persistent)\n'
+                'H=1: 1/f noise (pink noise)\n'
+                'H>1: non-stationary behavior (random walk, Brownian motion)'
+            )
+            ax.text(
+                0.95,
+                0.05,
+                note,
+                transform=ax.transAxes,
+                fontsize=8,
+                verticalalignment='bottom',
+                horizontalalignment='right',
+                bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.8)
+            )
             ax.legend()
             fig.tight_layout()
             fig.savefig("DFA.png", dpi=300, bbox_inches='tight')

--- a/analysis/lstm.py
+++ b/analysis/lstm.py
@@ -60,45 +60,47 @@ class LSTMAnalysis:
             y_train_pred_inv = scaler.inverse_transform(y_train_pred.reshape(-1,1)).flatten()
             y_test_pred_inv = scaler.inverse_transform(y_test_pred.reshape(-1,1)).flatten()
             
-            fig3, ax3 = plt.subplots()
-            ax3.plot(time_train, y_train_inv, label='Real (Train)')
-            ax3.plot(time_train, y_train_pred_inv, '--', label='Predicción (Train)')
-            ax3.plot(time_test, y_test_inv, label='RealalternativesReal (Test)')
-            ax3.plot(time_test, y_test_pred_inv, '--', label='Predicción (Test)')
-            ax3.set_xlabel('Tiempo (measurement_time)')
-            ax3.set_ylabel('Concentración de metano (ppb)')
-            ax3.legend()
-            file1 = guardar_fig(fig3, "LSTM.png")
-            generated_files.append(file1)
-            
             ultima_ventana = data_scaled[-ventana:].reshape(1, ventana, 1)
             predicciones_futuras = []
             fechas_futuras = []
-            
+
             fecha_base = df['measurement_time'].iloc[-1]
             for i in range(180):
                 pred = model.predict(ultima_ventana)[0, 0]
                 predicciones_futuras.append(pred)
                 nueva_fecha = fecha_base + timedelta(days=i + 1)
                 fechas_futuras.append(nueva_fecha)
-                
+
                 nueva_entrada = np.append(ultima_ventana[0, 1:, 0], pred).reshape(1, ventana, 1)
                 ultima_ventana = nueva_entrada
-                
+
             predicciones_futuras_inv = scaler.inverse_transform(np.array(predicciones_futuras).reshape(-1, 1)).flatten()
-            
-            fig_future, axf = plt.subplots()
-            axf.plot(df['measurement_time'], df['methane3'], label='Histórico')
-            axf.plot(fechas_futuras, predicciones_futuras_inv, '--', color='red', label='Predicción futura (6 meses)')
-            axf.set_xlabel('Tiempo (measurement_time)')
-            axf.set_ylabel('Concentración de metano (ppb)')
-            axf.set_title('Predicción futura con LSTM')
-            axf.legend()
-            file2 = "LSTM_Futuro.png"
-            fig_future.savefig(file2, bbox_inches='tight')
-            plt.close(fig_future)
-            generated_files.append(file2)
-            
+
+            fig, ax = plt.subplots()
+            ax.plot(time_train, y_train_inv, label='Real (Train)')
+            ax.plot(time_train, y_train_pred_inv, '--', label='Predicción (Train)')
+            ax.plot(time_test, y_test_inv, label='Real (Test)')
+            ax.plot(time_test, y_test_pred_inv, '--', label='Predicción (Test)')
+            ax.plot(
+                fechas_futuras,
+                predicciones_futuras_inv,
+                '--',
+                color='red',
+                label='Predicción futura (6 meses)'
+            )
+            ax.axvspan(
+                fechas_futuras[0],
+                fechas_futuras[-1],
+                color='yellow',
+                alpha=0.1,
+                label='Etapa de aplicación'
+            )
+            ax.set_xlabel('Tiempo (measurement_time)')
+            ax.set_ylabel('Concentración de metano (ppb)')
+            ax.set_title('Predicción con LSTM')
+            ax.legend()
+            file = guardar_fig(fig, "LSTM.png")
+            generated_files.append(file)
             return generated_files, None
             
         except Exception as e:

--- a/analysis/psa.py
+++ b/analysis/psa.py
@@ -9,7 +9,6 @@ class PSAAnalysis:
             import matplotlib.pyplot as plt
             from scipy.fft import fft, fftfreq
             from scipy.stats import linregress
-            from statsmodels.tsa.stattools import acf, kpss
 
             df = pd.read_csv(data_file, parse_dates=['measurement_time'])
             df.sort_values('measurement_time', inplace=True)
@@ -18,33 +17,6 @@ class PSAAnalysis:
             slope, intercept, *_ = linregress(df['time_numeric'], df['methane3'])
             df['methane3_detrended'] = df['methane3'] - (slope * df['time_numeric'] + intercept)
 
-            plt.figure(figsize=(12, 4))
-            plt.plot(df['measurement_time'], df['methane3'], label='Original', alpha=0.6)
-            plt.plot(df['measurement_time'], df['methane3_detrended'], label='Detrended')
-            plt.title('Methane Concentration: Original vs Detrended')
-            plt.xlabel('Time')
-            plt.ylabel('Methane3')
-            plt.legend()
-            plt.tight_layout()
-            plt.savefig('methane_original_vs_detrended.png', dpi=300)
-            plt.close()
-
-            acf_values = acf(df['methane3_detrended'], nlags=100)
-            plt.figure(figsize=(10, 4))
-            plt.stem(range(len(acf_values)), acf_values)
-            plt.title('Autocorrelation of Detrended Methane3')
-            plt.xlabel('Lag')
-            plt.ylabel('ACF')
-            plt.tight_layout()
-            plt.savefig('autocorrelation_detrended_methane3.png', dpi=300)
-            plt.close()
-
-            stat, p_value, _, crit_vals = kpss(df['methane3_detrended'], regression='c')
-            with open('kpss_results.txt', 'w') as f:
-                f.write(f'KPSS Test Statistic: {stat:.4f}\n')
-                f.write(f'p-value: {p_value:.4f}\n')
-                for k, v in crit_vals.items():
-                    f.write(f'Critical Value {k}: {v:.4f}\n')
 
             signal = df['methane3_detrended'].to_numpy()
             n = len(signal)
@@ -57,6 +29,14 @@ class PSAAnalysis:
             log_power = np.log10(power_spectrum[mask])
             slope, intercept = np.polyfit(log_freq, log_power, 1)
             beta = -slope
+            if beta < 0.3:
+                explanation = "White noise-like process (uncorrelated, flat spectrum)"
+            elif beta < 1.2:
+                explanation = "Pink noise-like process (1/f scaling, correlated fluctuations)"
+            elif beta < 2.5:
+                explanation = "Brownian or red noise (integrated or persistent behavior)"
+            else:
+                explanation = "Strong low-frequency dominance or nonstationary trend"
 
             plt.figure(figsize=(8, 5))
             plt.plot(log_freq, log_power, label='Log Power Spectrum')
@@ -66,37 +46,40 @@ class PSAAnalysis:
             plt.ylabel('log10(Power)')
             plt.legend()
             plt.grid(True)
+            note = (
+                'β=0: white noise\n'
+                'β=1: pink noise (1/f)\n'
+                'β=2: Brownian noise'
+            )
+            ax = plt.gca()
+            ax.text(
+                0.95,
+                0.95,
+                note,
+                transform=ax.transAxes,
+                fontsize=8,
+                verticalalignment='top',
+                horizontalalignment='right',
+                bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.8)
+            )
+            ax.text(
+                0.95,
+                0.75,
+                f"β ≈ {beta:.2f}\n{explanation}",
+                transform=ax.transAxes,
+                fontsize=8,
+                verticalalignment='top',
+                horizontalalignment='right',
+                bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.8)
+            )
             plt.tight_layout()
             plt.savefig('loglog_psd_with_beta.png', dpi=300)
             plt.close()
 
             with open("spectral_beta_result.txt", "w") as f:
-                f.write(f"Spectral exponent β (beta): {beta:.4f}\n")
-                if beta < 0.3:
-                    f.write("White noise-like process (uncorrelated, flat spectrum)\n")
-                elif beta < 1.2:
-                    f.write("Pink noise-like process (1/f scaling, correlated fluctuations)\n")
-                elif beta < 2.5:
-                    f.write("Brownian or red noise (integrated or persistent behavior)\n")
-                else:
-                    f.write("Strong low-frequency dominance or nonstationary trend\n")
+                f.write(f"Spectral exponent β (beta): {beta:.4f}\n{explanation}\n")
 
-            plt.figure(figsize=(10, 4))
-            plt.plot(xf, 2.0/n * np.abs(yf[0:n//2]))
-            plt.title('Power Spectral Density of Detrended Methane3')
-            plt.xlabel('Frequency [Hz]')
-            plt.ylabel('Amplitude')
-            plt.grid(True)
-            plt.tight_layout()
-            plt.savefig('power_spectral_density_methane3.png', dpi=300)
-            plt.close()
-
-            return [
-                'methane_original_vs_detrended.png',
-                'autocorrelation_detrended_methane3.png',
-                'loglog_psd_with_beta.png',
-                'power_spectral_density_methane3.png'
-            ], None
+            return ['loglog_psd_with_beta.png'], None
 
         except Exception as e:
             return [], str(e)


### PR DESCRIPTION
## Summary
- show DFA Hurst explanations on the plot
- show PSA spectral beta notes on the plot
- combine train/test/future output for LSTM into one figure
- highlight the LSTM application stage on the plot

## Testing
- `python -m py_compile analysis/psa.py analysis/dfa.py analysis/lstm.py`


------
https://chatgpt.com/codex/tasks/task_e_68629d993780832284bd51a86a37ea8f