### PR TITLE
Fix mass estimation weekly plot and image filtering

### DIFF
--- a/analysis/mass_estimation.py
+++ b/analysis/mass_estimation.py
@@ -51,7 +51,7 @@ class MassEstimation:
             yearly_plot = 'yearly_mass.png'
 
             fig_w, ax_w = plt.subplots(figsize=(10, 4))
-            weekly_mass.plot(kind='bar', ax=ax_w, color='skyblue')
+            ax_w.bar(range(len(weekly_mass)), weekly_mass.values, color='skyblue', edgecolor='black')
             step_w = max(1, len(weekly_mass) // 10)
             ax_w.set_xticks(range(0, len(weekly_mass), step_w))
             ax_w.set_xticklabels(weekly_mass.index[::step_w], rotation=45, ha='right')

--- a/app.py
+++ b/app.py
@@ -882,7 +882,9 @@ class MethaneAnalysisApp(ctk.CTk):
             
         mass_patterns = [
             'methane_mass_map*.png',
-            '*mass*.png'
+            'weekly_mass.png',
+            'monthly_mass.png',
+            'yearly_mass.png'
         ]
         
         image_files = []


### PR DESCRIPTION
## Summary
- prevent unrelated K-means mass images from appearing in mass estimation tab
- adjust weekly mass plot to always use a visible blue color

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862da2e87788322b3f58c270e54046c