### PR TITLE
Fix mass images filtering

### DIFF
--- a/analysis/mass_estimation.py
+++ b/analysis/mass_estimation.py
@@ -51,7 +51,7 @@ class MassEstimation:
             yearly_plot = 'yearly_mass.png'
 
             fig_w, ax_w = plt.subplots(figsize=(10, 4))
-            weekly_mass.plot(kind='bar', ax=ax_w, color='skyblue')
+            ax_w.bar(range(len(weekly_mass)), weekly_mass.values, color='skyblue', edgecolor='black')
             step_w = max(1, len(weekly_mass) // 10)
             ax_w.set_xticks(range(0, len(weekly_mass), step_w))
             ax_w.set_xticklabels(weekly_mass.index[::step_w], rotation=45, ha='right')

--- a/app.py
+++ b/app.py
@@ -803,7 +803,8 @@ class MethaneAnalysisApp(ctk.CTk):
             f'tula_methane3_hist_{mode}_cluster_*.png',
             f'tula_methane3_boxplot_{mode}_cluster.png',
             f'tula_methane3_box_swarmplot_{mode}_cluster.png',
-            f'tula_kmeans_{mode}_time_scatter.png'
+            f'tula_kmeans_{mode}_time_scatter.png',
+            f'tula_methane_mass_yearly_stacked_{mode}_cluster.png'
         ]
         
         image_files = []
@@ -882,7 +883,9 @@ class MethaneAnalysisApp(ctk.CTk):
             
         mass_patterns = [
             'methane_mass_map*.png',
-            '*mass*.png'
+            'weekly_mass.png',
+            'monthly_mass.png',
+            'yearly_mass.png'
         ]
         
         image_files = []


### PR DESCRIPTION
## Summary
- include yearly mass stacked plots in K-means image refresh
- ensure weekly mass bars draw with black edges
- load only direct mass estimation images in Mass Estimation tab

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6862da2e87788322b3f58c270e54046c