### PR TITLE
Add cluster methane mass plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,41 +7,45 @@ deviation, minimum and maximum) on the generated plot.
 
 For K-means clustering in `lat_lon` mode, the analysis no longer outputs the
 `tula_kmeans_lat_lon_clusters.csv` or `tula_kmeans_lat_lon_conteos.txt` files.
-Cluster counts are shown in the title of the spatial scatter plot. Three plots
+Cluster counts are shown in the title of the spatial scatter plot. Four plots
 are produced:
 ``tula_kmeans_lat_lon_metricas_vs_K.png``,
-``tula_kmeans_lat_lon_space_scatter_basemap.png`` and
-``tula_methane3_stacked_hist_lat_lon_cluster.png``.
+``tula_kmeans_lat_lon_space_scatter_basemap.png``,
+``tula_methane3_stacked_hist_lat_lon_cluster.png`` and
+``tula_methane_mass_yearly_stacked_lat_lon_cluster.png``.
 
 Similarly, for the `time_lat_lon` mode the analysis does not generate
 `tula_kmeans_time_lat_lon_clusters.csv` or
 `tula_kmeans_time_lat_lon_conteos.txt`. The cluster count statistics that would
 normally be stored in the text file are displayed directly in the title of the
-`tula_kmeans_time_lat_lon_space_scatter_basemap.png` plot. Four plots are
+`tula_kmeans_time_lat_lon_space_scatter_basemap.png` plot. Five plots are
 produced:
 ``tula_kmeans_time_lat_lon_metricas_vs_K.png``,
 ``tula_kmeans_time_lat_lon_space_scatter_basemap.png``,
 ``tula_kmeans_time_lat_lon_time_scatter.png`` and
-``tula_methane3_stacked_hist_time_lat_lon_cluster.png``.
+``tula_methane3_stacked_hist_time_lat_lon_cluster.png`` and
+``tula_methane_mass_yearly_stacked_time_lat_lon_cluster.png``.
 
 The WCSS, Silhouette Score and Davies-Bouldin Index plots for all K-means modes
 highlight the chosen cluster count using a dashed vertical line and a purple
 scatter marker. Each plot now labels the marker with text like ``K = 3`` placed
 to the right of the point, making the optimal cluster number easy to identify.
 
-For the ``lat_lon_methane`` mode four plots are produced:
+For the ``lat_lon_methane`` mode five plots are produced:
 ``tula_kmeans_lat_lon_methane_metricas_vs_K.png``,
 ``tula_kmeans_lat_lon_methane_space_scatter_basemap.png``,
 ``tula_methane3_box_swarmplot_lat_lon_methane_cluster.png`` and
-``tula_methane3_stacked_hist_lat_lon_methane_cluster.png``. No CSV or text
-files are saved and intermediate methane boxplot images are not generated.
+``tula_methane3_stacked_hist_lat_lon_methane_cluster.png`` and
+``tula_methane_mass_yearly_stacked_lat_lon_methane_cluster.png``. No CSV or
+text files are saved and intermediate methane boxplot images are not generated.
 
-In ``time_lat_lon_methane`` mode five plots are produced:
+In ``time_lat_lon_methane`` mode six plots are produced:
 ``tula_kmeans_time_lat_lon_methane_metricas_vs_K.png``,
 ``tula_kmeans_time_lat_lon_methane_space_scatter_basemap.png``,
 ``tula_kmeans_time_lat_lon_methane_time_scatter.png``,
 ``tula_methane3_box_swarmplot_time_lat_lon_methane_cluster.png`` and
-``tula_methane3_stacked_hist_time_lat_lon_methane_cluster.png``. Other plots
+``tula_methane3_stacked_hist_time_lat_lon_methane_cluster.png`` and
+``tula_methane_mass_yearly_stacked_time_lat_lon_methane_cluster.png``. Other plots
 as well as CSV or text files are omitted.
 
 The DFA (Detrended Fluctuation Analysis) plot labels the y-axis as

--- a/analysis/kmeans_analysis.py
+++ b/analysis/kmeans_analysis.py
@@ -35,10 +35,16 @@ class KMeansAnalysis:
             os.makedirs('clusters_espaciales', exist_ok=True)
             os.makedirs('subclusters_methane3', exist_ok=True)
             
-            include_time = 'time' in mode.lower()
             include_methane = 'methane' in mode.lower()
-            
-            df = KMeansAnalysis.cargar_datos(data_file, include_time, include_methane)
+
+            # Always load the measurement_time column so that methane mass
+            # can be estimated for each cluster regardless of the clustering
+            # features used.
+            df = KMeansAnalysis.cargar_datos(
+                data_file, include_time=True, include_methane=include_methane
+            )
+
+            include_time = 'time' in mode.lower()
             
             if mode == 'time_lat_lon':
                 df['timestamp'] = pd.to_datetime(df['measurement_time']).view('int64') // 10**9
@@ -337,7 +343,47 @@ class KMeansAnalysis:
                 plt.savefig(stacked_hist_file, dpi=300)
                 plt.close()
                 generated_files.append(stacked_hist_file)
-            
+
+            # Estimate methane mass per cluster and generate a stacked yearly
+            # bar chart. Only run this step when methane concentrations and
+            # measurement times are available.
+            if has_methane and 'measurement_time' in df.columns:
+                M_CH4 = 16.04e-3
+                M_air = 28.97e-3
+                rho_air = 1.2
+                mixing_height_m = 1000
+                pixel_area_m2 = 1e6
+
+                def ppb_to_kg_m3(ppb):
+                    return ppb * (1e-9 * M_CH4 * rho_air / M_air)
+
+                df['methane_mass_kg'] = (
+                    ppb_to_kg_m3(df['methane3']) * pixel_area_m2 * mixing_height_m
+                )
+                df['year'] = pd.to_datetime(df['measurement_time']).dt.year
+                yearly_mass = (
+                    df.groupby(['year', cluster_column])['methane_mass_kg']
+                    .sum()
+                    .unstack(fill_value=0)
+                    / 1000
+                )
+
+                ax = yearly_mass.plot(
+                    kind='bar', stacked=True, figsize=(10, 6), colormap='tab10'
+                )
+                ax.set_xlabel('Año')
+                ax.set_ylabel('Masa total (toneladas)')
+                ax.set_title(
+                    f'Masa anual estimada de metano por cluster (K={best_k}) - {mode}'
+                )
+                plt.tight_layout()
+                mass_yearly_file = (
+                    f'tula_methane_mass_yearly_stacked_{mode}_cluster.png'
+                )
+                plt.savefig(mass_yearly_file, dpi=300)
+                plt.close()
+                generated_files.append(mass_yearly_file)
+
             return generated_files, None
             
         except Exception as e:

--- a/app.py
+++ b/app.py
@@ -880,9 +880,12 @@ class MethaneAnalysisApp(ctk.CTk):
         if not hasattr(self, 'mass_image_viewer'):
             return
             
+        # Only show images produced by the mass estimation analysis itself.
         mass_patterns = [
             'methane_mass_map*.png',
-            '*mass*.png'
+            'weekly_mass.png',
+            'monthly_mass.png',
+            'yearly_mass.png'
         ]
         
         image_files = []


### PR DESCRIPTION
## Summary
- always load measurement time in KMeans analysis
- calculate methane mass per cluster and plot stacked yearly totals
- document new output files in README
- only show mass estimation plots in the Mass Estimation tab

## Testing
- `python -m py_compile analysis/kmeans_analysis.py analysis/mass_estimation.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6862d0a31af4832283777d3e05e32ebd